### PR TITLE
Multiple bugfixes

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -43,7 +43,6 @@
 # We need to flush here in case interfaces are configured in zebra.conf
 - name: config | Flusing Handlers
   meta: flush_handlers
-  when: _frr_zebra_configured['changed']
 
 # We need to rediscover facts if interfaces are initially configured in zebra.conf
 - name: config | Rediscovering Facts

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -46,6 +46,7 @@
     name: "{{ frr_debs }}"
     state: present
   become: true
+  register: _frrdownload
   when:
     - ansible_distribution == "CentOS"
     - ansible_distribution_major_version == "7"

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -33,7 +33,7 @@ interface {{ iface }}
   ip ospf message-digest-key {{ iface_data['auth']['id'] }} md5 {{ iface_data['auth']['key'] }}
 {%     endif %}
 {%     if iface_data['other'] is defined %}
-{%       for option in iface_data['other'].items() %}
+{%       for option in iface_data['other'] %}
   {{ option }}
 {%       endfor %}
 {%     endif %}


### PR DESCRIPTION
I fixed bug in frr.conf.j2 template, which was probably introduced by conversion to python3. The example in README suggest, that interface other values should be lists. If I configured frr_interfaces variable like RADME says, the ansible 2.9.5 threw error: "FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'list object' has no attribute 'items'"}". After I removed function items() in j2 template it worked fine.

Also I removed conditonal for flush_handlers task, which is not support them (ref. https://github.com/ansible/ansible/issues/41313)

Also I added missing register variable in redhat.yml, which caused, that on redhat/centos systems frr daemon reload failed because undefined variable _frrdownload