### PR TITLE
Allow install from official FRR RPM repo for RedHat like systems

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -113,6 +113,11 @@ frr_version: 6.0.2
 frr_apt_version: frr-stable
 frr_apt_repository: "deb https://deb.frrouting.org/frr {{ ansible_distribution_release }} {{ frr_apt_version }}"
 
+# Defines FRR rpm repo
+# https://rpm.frrouting.org/
+frr_rpm_version: frr-stable
+frr_rpm_repository: "https://rpm.frrouting.org/repo/{{ frr_rpm_version }}-repo-1-0.el{{ ansible_distribution_major_version }}.noarch.rpm"
+
 _frr_bgp_summary:
   stdout: ""
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,13 @@
        - ansible_distribution == "Ubuntu"
        - ansible_distribution_version >= "20.04"
    - include_tasks: redhat.yml
-     when: ansible_os_family == "RedHat"
+     when:
+       - ansible_os_family == "RedHat"
+       - frr_version|float is version("7.0", ">=")
+   - include_tasks: redhat_legacy.yml
+     when:
+       - ansible_os_family == "RedHat"
+       - frr_version|float is version("7.0", "<")
    - include_tasks: system_tuning.yml
    - include_tasks: config.yml
    - include_tasks: monitor.yml

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -6,47 +6,24 @@
   become: true
   when: ansible_distribution != "Fedora"
 
-- name: set url on frr version less than or equal to 4.1
-  set_fact:
-    frr_url_part: "{{ frr_release_date }}"
-  when:
-    - frr_version <= "4.1"
-
-- name: set url on frr version 5
-  set_fact:
-    frr_url_part: "001"
-  when:
-    - frr_version == "5.0.2"
-
-- name: set url on frr version 6
-  set_fact:
-    frr_url_part: "01"
-  when:
-    - frr_version >= "6"
-
-- name: redhat | Create FRR {{ frr_version }} install
-  set_fact:
-    frr_debs:
-      [
-        "{{ frr_package_url }}/frr-{{ frr_version }}-{{ frr_url_part }}.el7.centos.x86_64.rpm",
-      ]
+- name: redhat | Installing FRR repository
+  yum:
+    name: "{{ frr_rpm_repository }}"
+    state: present
   become: true
+  when:
+    - (ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")
 
-- name: redhat | Create Python Tools FRR {{ frr_version }} install
-  set_fact:
-    frr_package_deb: "{{ frr_package_url }}/frr-pythontools-{{ frr_version }}-{{ frr_url_part }}.el7.centos.x86_64.rpm"
-
-- name: redhat | Combine FRR {{ frr_version }} and tools
-  set_fact:
-    frr_debs: "{{ frr_debs }} + [ '{{ frr_package_deb }}' ]"
-  when: frr_reload|bool
+- name: redhat | Ensure Quagga is removed
+  package:
+    name: quagga
+    state: absent
+  become: true
 
 - name: redhat | Installing FRR {{ frr_version }}
   yum:
-    name: "{{ frr_debs }}"
+    name:
+      - frr
+      - frr-pythontools
     state: present
   become: true
-  register: _frrdownload
-  when:
-    - ansible_distribution == "CentOS"
-    - ansible_distribution_major_version == "7"

--- a/tasks/redhat_legacy.yml
+++ b/tasks/redhat_legacy.yml
@@ -1,0 +1,52 @@
+---
+- name: redhat | Installing Pre-Reqs
+  yum:
+    name: ["iproute", "sudo", "which"]
+    state: present
+  become: true
+  when: ansible_distribution != "Fedora"
+
+- name: set url on frr version less than or equal to 4.1
+  set_fact:
+    frr_url_part: "{{ frr_release_date }}"
+  when:
+    - frr_version <= "4.1"
+
+- name: set url on frr version 5
+  set_fact:
+    frr_url_part: "001"
+  when:
+    - frr_version == "5.0.2"
+
+- name: set url on frr version 6
+  set_fact:
+    frr_url_part: "01"
+  when:
+    - frr_version >= "6"
+
+- name: redhat | Create FRR {{ frr_version }} install
+  set_fact:
+    frr_debs:
+      [
+        "{{ frr_package_url }}/frr-{{ frr_version }}-{{ frr_url_part }}.el7.centos.x86_64.rpm",
+      ]
+  become: true
+
+- name: redhat | Create Python Tools FRR {{ frr_version }} install
+  set_fact:
+    frr_package_deb: "{{ frr_package_url }}/frr-pythontools-{{ frr_version }}-{{ frr_url_part }}.el7.centos.x86_64.rpm"
+
+- name: redhat | Combine FRR {{ frr_version }} and tools
+  set_fact:
+    frr_debs: "{{ frr_debs }} + [ '{{ frr_package_deb }}' ]"
+  when: frr_reload|bool
+
+- name: redhat | Installing FRR {{ frr_version }}
+  yum:
+    name: "{{ frr_debs }}"
+    state: present
+  become: true
+  register: _frrdownload
+  when:
+    - ansible_distribution == "CentOS"
+    - ansible_distribution_major_version == "7"


### PR DESCRIPTION
This solves issue https://github.com/mrlesmithjr/ansible-frr/issues/38, implemented like https://github.com/mrlesmithjr/ansible-frr/commit/0744dd88b29741a1b42efbdcbf56d47f650cc989

- used only when FRR version > 7
- moved legacy install tasks to redhat_legacy.yml
- introduced vars frr_rpm_version & frr_rpm_repository