### PR TITLE
Make debug option for verbose loggin

### DIFF
--- a/tasks/monitor.yml
+++ b/tasks/monitor.yml
@@ -41,7 +41,9 @@
     frr_daemons['bgpd'] and
     _frr_service_status['status']['SubState'] == "running"
 
-- debug: var=_frr_bgp_summary['stdout']
+- debug:
+    var: _frr_bgp_summary['stdout']
+    verbosity: 1
   when:
     - _frr_bgp_summary['stdout'] is defined
     - _frr_bgp_summary['stdout'] != "" # noqa 602


### PR DESCRIPTION
This makes it where the output only shows when we do a verbose run. This cleans up logs for various things.