### PR TITLE
BGP Listen Range Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ frr_bgp:
         192.168.250.12:
           peer_group: group1
           description: far_away
+      listen_range:
+        192.168.250.0/24: group1
       networks:
         - "{{ frr_router_id }}/32"
         - "{{ hostvars[inventory_hostname]['ansible_enp0s8']['ipv4']['address'] }}/24"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,9 @@ frr_bgp: {}
   #         v4_route_reflector_client: true
   #         other:
   #           - "prefix-list Bad_IPs in"
+  #     listen_range:
+  #       192.168.250.0/24: any_peer_group
+  #       "2600::/64": any_v6_peer_group
   #     networks:
   #       - "{{ frr_router_id }}/32"
   #       - "{{ hostvars[inventory_hostname]['ansible_enp0s8']['ipv4']['address'] }}/24"

--- a/tasks/quagga.yml
+++ b/tasks/quagga.yml
@@ -51,30 +51,6 @@
     - start quagga
   when: ansible_os_family == "Debian"
 
-- name: config | Configuring zebra.conf
-  template:
-    backup: yes
-    src: etc/frr/zebra.conf.j2
-    dest: /etc/quagga/zebra.conf
-    owner: quagga
-    group: quagga
-    mode: u=rw,g=r,o=
-  become: true
-  register: _quagga_zebra_configured
-  notify:
-    - restart quagga
-    - start quagga
-
-# We need to flush here in case interfaces are configured in zebra.conf
-- name: config | Flusing Handlers # noqa 503
-  meta: flush_handlers
-  when: _quagga_zebra_configured['changed']
-
-# We need to rediscover facts if interfaces are initially configured in zebra.conf
-- name: config | Rediscovering Facts # noqa 503
-  setup:
-  when: _quagga_zebra_configured['changed']
-
 - name: config | Configuring Quagga
   template:
     backup: yes

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -182,10 +182,16 @@ router bgp {{ asn }}
 {%             endif %}
   exit-address-family
 !
-!
 {%           endif %}
 {%         endfor %}
 {%       endif %}
+!
+{%       if asn_data['listen_range'] is defined %}
+{%         for listen_range, listen_range_peer_group in asn_data['listen_range'].items() %}
+  bgp listen range {{ listen_range }} peer-group {{ listen_range_peer_group }}
+{%         endfor %}
+{%       endif %}
+!
 {%       if asn_data['networks'] | default(False) or
             asn_data['redistribute'] | default(False) %}
   address-family ipv4 unicast


### PR DESCRIPTION
This allows for BGP listen range support - that way we can listen to a whole range of ips in a subnet for neighborship.