### PR TITLE
Adding BGP route-map in the example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ frr_bgp:
           default_originate: false
           description: node1
           next_hop_self: true
+          v4_route_map: ["RTBH out", "RTBH_IN in"]
           af_v4:
             - "soft-reconfiguration inbound"
         192.168.250.12:
@@ -294,6 +295,7 @@ frr_bgp:
           af_v6:
             - "activate"
             - "soft-reconfiguration inbound"
+            - "route_map RTBH out"
       networks:
         - "{{ frr_router_id }}/32"
         - "{{ hostvars[inventory_hostname]['ansible_enp0s8']['ipv4']['address'] }}/24"


### PR DESCRIPTION
Adding BGP route-map in the example config

## Description
This repo looks cool and I was trying to find a way to add a route-map , so I thought it might be a good idea to add it into the example config 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
