### PR TITLE
Add support for VRFs in BFD

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -152,6 +152,11 @@ frr_apt_repository: "deb https://deb.frrouting.org/frr {{ ansible_distribution_r
 frr_rpm_version: frr-stable
 frr_rpm_repository: "https://rpm.frrouting.org/repo/{{ frr_rpm_version }}-repo-1-0.el{{ ansible_distribution_major_version }}.noarch.rpm"
 
+frr_packages:
+  - frr
+  - python3-ipaddr
+  - frr-pythontools
+
 _frr_bgp_summary:
   stdout: ""
 

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -58,10 +58,7 @@
 
 - name: Install FRR
   package:
-    name:
-      - frr
-      - python-ipaddr
-      - frr-pythontools
+    name: "{{ frr_packages }}"
     state: latest  # noqa 403
   become: true
   notify:

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -61,6 +61,12 @@ ip forwarding
 ipv6 forwarding
 {% endif %}
 !
+{% if frr_vrf_static is defined and frr_vrf_static != {} %}
+{%   for route, values in frr_vrf_static.items() %}
+ip route {{ route }} {{ values.gw }} vrf {{ values.gw }}
+{%   endfor %}
+{% endif %}
+!
 {% if frr_daemons['bgpd'] %}
 {%   if frr_bgp is defined and frr_bgp != {} %}
 {%     for asn, asn_data in frr_bgp['asns'].items() %}

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -376,6 +376,9 @@ route-map {{ map_name }} {{ seq }}
 {%       if seq_data['origin'] is defined %}
   set origin {{ seq_data['origin'] }}
 {%       endif %}
+{%       if seq_data['local-preference'] is defined %}
+  set local-preference {{ seq_data['local-preference'] }}
+{%       endif %}
 !
 {%     endfor %}
 {%   endfor %}

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -251,29 +251,34 @@ bfd
 {%       if asn_data['neighbors'] is defined %}
 {%         for neighbor, neighbor_data in asn_data['neighbors'].items() | sort(reverse=True, attribute="1.is_peer_group") %}
 {%           if neighbor_data['bfd_peer'] | default(False) %}
+{%             if asn_data['vrf'] is defined and asn_data['vrf']|length %}
+  peer {{ neighbor }} vrf {{ asn_data['vrf'] }}
+    no shutdown
+{%             else %}
   peer {{ neighbor }}
     no shutdown
-{%           endif %}
-{%           if neighbor_data['bfd_peer_detect_multiplier'] | default(False) %}
+{%             endif %}
+{%             if neighbor_data['bfd_peer_detect_multiplier'] | default(False) %}
     detect-multiplier {{ neighbor_data['bfd_peer_detect_multiplier'] }}
-{%           endif %}
-{%           if neighbor_data['bfd_peer_receive_interval'] | default(False) %}
+{%             endif %}
+{%             if neighbor_data['bfd_peer_receive_interval'] | default(False) %}
     receive-interval {{ neighbor_data['bfd_peer_receive_interval'] }}
-{%           endif %}
-{%           if neighbor_data['bfd_peer_transmit_interval'] | default(False) %}
+{%             endif %}
+{%             if neighbor_data['bfd_peer_transmit_interval'] | default(False) %}
     transmit-interval {{ neighbor_data['bfd_peer_transmit_interval'] }}
-{%           endif %}
-{%           if neighbor_data['bfd_peer_echo_interval'] | default(False) %}
+{%             endif %}
+{%             if neighbor_data['bfd_peer_echo_interval'] | default(False) %}
     echo-interval {{ neighbor_data['bfd_peer_echo_interval'] }}
-{%           endif %}
-{%           if neighbor_data['bfd_peer_echo_mode'] | default(False) %}
+{%             endif %}
+{%             if neighbor_data['bfd_peer_echo_mode'] | default(False) %}
     echo-mode
-{%           endif %}
-{%           if neighbor_data['bfd_peer_passive_mode'] | default(False) %}
+{%             endif %}
+{%             if neighbor_data['bfd_peer_passive_mode'] | default(False) %}
     passive-mode
-{%           endif %}
-{%           if neighbor_data['bfd_peer_minimum_ttl'] | default(False) %}
+{%             endif %}
+{%             if neighbor_data['bfd_peer_minimum_ttl'] | default(False) %}
     minimum-ttl {{ neighbor_data['bfd_peer_minimum_ttl'] }}
+{%             endif %}
 {%           endif %}
 {%         endfor %}
 {%       endif %}

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -63,7 +63,7 @@ ipv6 forwarding
 !
 {% if frr_vrf_static is defined and frr_vrf_static != {} %}
 {%   for route, values in frr_vrf_static.items() %}
-ip route {{ route }} {{ values.gw }} vrf {{ values.gw }}
+ip route {{ route }} {{ values.gw }} vrf {{ values.vrf }}
 {%   endfor %}
 {% endif %}
 !


### PR DESCRIPTION
## Description
This PR provides VRF support to BFD peers.  This is achieved by adding an optional `vrf` variable to the BGP AS configuration. This optional variable could be used in the future for better defining BGP ASs that use VRFs. Note that currently you can define an AS with a VRF like this:
```
frr_bgp:
  asns:
    '65001 vrf vrf-red':
    ...
```
In addition I found that if you set `bfd_peer` to `false` for a neighbor it led to incomplete BFD configuration which this PR also addresses.

## Related Issue
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x  ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
