### PR TITLE
Add a 'metric' option to the route-map template

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ frr_route_map:
       prefix_list: Bad_IPs
       origin: igp
       community: "12345:100"
+      metric: 100
   RTBH_IN:
     deny 10: []
 ```

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -365,6 +365,9 @@ route-map {{ map_name }} {{ seq }}
 {%       if seq_data['origin'] is defined %}
   set origin {{ seq_data['origin'] }}
 {%       endif %}
+{%       if seq_data['metric'] is defined %}
+  set metric {{ seq_data['metric'] }}
+{%       endif %}
 !
 {%     endfor %}
 {%   endfor %}


### PR DESCRIPTION
## Description
I have added a 'metric' option to the template for adding route maps, this is for setting the MED on the BGP advertisement.

## Related Issue
Resolved #67

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

There are some possibly failing tests on centos I think but I don't believe they are caused by this PR.
