### PR TITLE
Fixes for redhat install & lint fixes

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -48,3 +48,9 @@
   notify:
     - reload frr
     - start frr
+
+- name: config | Ensure FRR service is enabled
+  service:
+    name: frr
+    enabled: true
+  become: true

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -17,7 +17,7 @@
         state: present
       become: true
       when: add_repository_key is failed
-    
+
     - name: Add FRR apt key (alternative for older systems without SNI).
       shell: |
         set -o pipefail
@@ -27,13 +27,13 @@
         executable: "/bin/bash"
       become: true
       when: add_repository_key is failed
-    
+
     - name: Ensure apt-transport-https is present to enable https repositories
       package:
         name: apt-transport-https
         state: present
       become: true
-    
+
     - name: Install FRR apt repo
       apt_repository:
         repo: "{{ frr_apt_repository }}"
@@ -48,7 +48,6 @@
     update_cache: true
   become: true
   when: frr_use_upstream_repo_debian | bool == false
-
 
 - name: Remove Quagga
   package:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -10,19 +10,21 @@
   yum:
     name: "{{ frr_rpm_repository }}"
     state: present
+    disable_gpg_check: true
   become: true
   when:
-    - (ansible_distribution == "CentOS" and ansible_distribution_major_version > "7") or
-      (ansible_distribution == "RedHat")
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version > "7"
 
 - name: redhat | Installing FRR repository ignore SSL
   yum:
     name: "{{ frr_rpm_repository }}"
     state: present
-    validate_certs: no
+    validate_certs: false
   become: true
   when:
-    - (ansible_distribution == "CentOS" and ansible_distribution_major_version <= "7")
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version <= "7"
 
 - name: redhat | Ensure Quagga is removed
   package:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

I fixed two errors on the RedHat family setup flow:
- The first one is the issue with GPG key missing when installing the RPM repository. This was solved by not validating GPG on this task. (This task installs the GPG key, which is used later when installing packages.)
- The second issue is with the FRR systemd service not enabled after role execution. This caused me some issues, when I thought, that FRR is ready for production and that I always had to fix manually when rebooting the server. There might be differences between the APT package and the RPM package(which I didn't investigate). This is executed for both RedHat and Debian family flow, but should not cause any issue if enabled already.

I also fixed some lint issues, which I found in Debian tasks file.


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
