### PR TITLE
Add support for Debian 11

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -13,6 +13,7 @@ jobs:
           - centos8
           - debian9
           - debian10
+          - debian11
           # - fedora
           - ubuntu1804
           - ubuntu2004

--- a/molecule/debian11/INSTALL.rst
+++ b/molecule/debian11/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/debian11/molecule.yml
+++ b/molecule/debian11/molecule.yml
@@ -1,0 +1,26 @@
+---
+dependency:
+  name: galaxy
+  enabled: false
+  options:
+    role-file: requirements.yml
+driver:
+  name: docker
+lint: |
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: debian11
+    image: mrlesmithjr/debian:11
+    privileged: true
+    command: /lib/systemd/systemd
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ../shared/converge.yml
+    prepare: ../shared/prepare.yml
+verifier:
+  name: ansible

--- a/molecule/debian11/verify.yml
+++ b/molecule/debian11/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true

--- a/vars/debian-11.yml
+++ b/vars/debian-11.yml
@@ -1,0 +1,5 @@
+---
+frr_packages:
+  - frr
+  - python3-ipaddr
+  - frr-pythontools


### PR DESCRIPTION
## Description
Debian 11 has `python3-ipaddr` instead of `python-ipaddr`. I made the necessary changes to add support for Debian 11.

## Related Issue
This closes #72

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

P.S Can't run the tests as the fail to an unrelated issue with `ruamel.yaml`, see #72 for more information.