### PR TITLE
Allow route-map for BGP as a protocol

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,6 +34,7 @@ frr_prefix_list: {}
   #     match: le 32
 
 frr_bgp: {}
+  # route_map: BGP_IN
   # asns:
   #   65000:
   #     log_neighbor_changes: true

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -440,4 +440,7 @@ route-map {{ map_name }} {{ seq }}
 access-list {{ ace }}
 {%   endfor %}
 {% endif %}
+{% if frr_bgp.route_map is defined %}
+ip protocol bgp route-map {{ frr_bgp.route_map }}
+{% endif %}
 !


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Allows the `ip protocol bgp <ROUTE_MAP>` statement to apply a route map to the BGP protocol as a whole.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have run the pre-merge tests locally and they pass.
