### PR TITLE
Add var to optionally not upgrade FRR apt package with every run

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -164,6 +164,7 @@ frr_version: "7.2"
 frr_use_upstream_repo_debian: true
 frr_apt_version: frr-stable
 frr_apt_repository: "deb https://deb.frrouting.org/frr {{ ansible_distribution_release }} {{ frr_apt_version }}"
+frr_apt_always_install_latest: true
 
 # Defines FRR rpm repo
 # https://rpm.frrouting.org/

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -59,7 +59,7 @@
 - name: Debian | Install FRR
   ansible.builtin.package:
     name: "{{ frr_packages }}"
-    state: latest  # noqa package-latest
+    state: "{{ 'latest' if frr_apt_always_install_latest else 'present' }}"
   become: true
   notify:
     - restart frr


### PR DESCRIPTION
This adds a `frr_apt_always_install_latest` variable that can optionally be set to `false` to not upgrade the FRR apt package every playbook run.