### PR TITLE
Add file for Debian 12 removing python-ipaddr

### DIFF
--- a/vars/debian-12.yml
+++ b/vars/debian-12.yml
@@ -1,0 +1,4 @@
+---
+frr_packages:
+  - frr
+  - frr-pythontools


### PR DESCRIPTION
## Description
Add vars file for debian 12, removing python-ipaddr

## Related Issue
https://github.com/mrlesmithjr/ansible-frr/issues/111

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

