### PR TITLE
Add Debian 13/Trixie support

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -11,6 +11,7 @@ jobs:
         molecule_distro:
           - debian11
           - debian12
+          - debian13
           - ubuntu2204
           - ubuntu2404
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
       versions:
         - bullseye
         - bookworm
+        - trixie
     - name: Ubuntu
       versions:
         - jammy

--- a/molecule/debian13/INSTALL.rst
+++ b/molecule/debian13/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule-plugins[docker]'

--- a/molecule/debian13/molecule.yml
+++ b/molecule/debian13/molecule.yml
@@ -1,0 +1,29 @@
+---
+dependency:
+  name: galaxy
+  enabled: false
+  options:
+    role-file: requirements.yml
+driver:
+  name: docker
+lint: |
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: debian13
+    image: mrlesmithjr/debian:13
+    privileged: true
+    command: /lib/systemd/systemd
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ../shared/converge.yml
+    prepare: ../shared/prepare.yml
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
+verifier:
+  name: ansible

--- a/molecule/debian13/verify.yml
+++ b/molecule/debian13/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Example assertion
+    ansible.builtin.assert:
+      that: true

--- a/molecule/debian13/verify.yml
+++ b/molecule/debian13/verify.yml
@@ -4,6 +4,33 @@
 - name: Verify
   hosts: all
   tasks:
-  - name: Example assertion
+  - name: Verify FRR package is installed
+    ansible.builtin.package_facts:
+      manager: apt
+
+  - name: Assert FRR is installed
     ansible.builtin.assert:
-      that: true
+      that: "'frr' in ansible_facts.packages"
+
+  - name: Assert signed-by keyring file exists
+    ansible.builtin.stat:
+      path: /etc/apt/keyrings/frrouting.gpg
+    register: _frr_verify_keyring_stat
+
+  - name: Assert keyring is present
+    ansible.builtin.assert:
+      that: _frr_verify_keyring_stat.stat.exists
+
+  - name: Get status of frr service
+    ansible.builtin.service:
+      name: frr
+    register: _frr_verify_service_status
+
+  - name: Assert frr service enabled and running
+    ansible.builtin.assert:
+      that:
+        - _frr_verify_service_status.status.ActiveState | default('n/a') == 'active'
+        - _frr_verify_service_status.status.LoadState | default('n/a') == 'loaded'
+        - _frr_verify_service_status.status.SubState | default('n/a') == 'running'
+        - _frr_verify_service_status.status.UnitFilePreset | default('n/a') == 'enabled'
+        - _frr_verify_service_status.status.UnitFileState | default('n/a') == 'enabled'

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -2,6 +2,58 @@
 - name: Debian | Add upstream repo
   when: frr_use_upstream_repo_debian
   block:
+    - name: Debian | Ensure /etc/apt/keyrings directory exists
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+      become: true
+      when: >
+        (
+          ansible_distribution == "Debian" and
+          ansible_distribution_major_version|int > 12
+        ) or
+        (
+          ansible_distribution == "Ubuntu" and
+          ansible_distribution_major_version|int > 24
+        )
+   
+    - name: Debian | Get FRR apt repo key
+      ansible.builtin.get_url:
+        url: https://deb.frrouting.org/frr/keys.gpg
+        dest: /etc/apt/keyrings/frrouting.gpg
+        owner: root
+        group: root
+        mode: "0644"
+      become: true
+      when: >
+        (
+          ansible_distribution == "Debian" and
+          ansible_distribution_major_version|int > 12
+        ) or
+        (
+          ansible_distribution == "Ubuntu" and
+          ansible_distribution_major_version|int > 24
+        )
+
+    - name: Debian | Ensure gnupg is present
+      ansible.builtin.package:
+        name:
+          - gnupg
+        state: present
+      become: true
+      when: >
+        (
+          ansible_distribution == "Debian" and
+          ansible_distribution_major_version|int > 12
+        ) or
+        (
+          ansible_distribution == "Ubuntu" and
+          ansible_distribution_major_version|int > 24
+        )
+
     - name: Debian | Install FRR apt repo key
       ansible.builtin.apt_key:
         url: https://deb.frrouting.org/frr/keys.asc
@@ -9,6 +61,15 @@
       become: true
       register: add_repository_key
       ignore_errors: true
+      when: >
+        (
+          ansible_distribution == "Debian" and
+          ansible_distribution_major_version|int <= 12
+        ) or
+        (
+          ansible_distribution == "Ubuntu" and
+          ansible_distribution_major_version|int <= 24
+        )
 
     - name: Debian | Ensure curl & gnupg is present (on older systems without SNI).
       ansible.builtin.package:
@@ -17,7 +78,19 @@
           - gnupg
         state: present
       become: true
-      when: add_repository_key is failed
+      when: >
+        add_repository_key is defined and
+        add_repository_key is failed and
+        (
+          (
+            ansible_distribution == "Debian" and
+            ansible_distribution_major_version|int <= 12
+          ) or
+          (
+            ansible_distribution == "Ubuntu" and
+            ansible_distribution_major_version|int <= 24
+          )
+        )
 
     - name: Debian | Add FRR apt key (alternative for older systems without SNI).
       ansible.builtin.shell:
@@ -28,7 +101,19 @@
         executable: "/bin/bash"
       become: true
       changed_when: false
-      when: add_repository_key is failed
+      when: >
+        add_repository_key is defined and
+        add_repository_key is failed and
+        (
+          (
+            ansible_distribution == "Debian" and
+            ansible_distribution_major_version|int <= 12
+          ) or
+          (
+            ansible_distribution == "Ubuntu" and
+            ansible_distribution_major_version|int <= 24
+          )
+        )
 
     - name: Debian | Ensure apt-transport-https is present to enable https repositories
       ansible.builtin.package:

--- a/vars/debian-13.yml
+++ b/vars/debian-13.yml
@@ -1,0 +1,4 @@
+---
+frr_packages:
+  - frr
+  - frr-pythontools

--- a/vars/debian-13.yml
+++ b/vars/debian-13.yml
@@ -2,3 +2,6 @@
 frr_packages:
   - frr
   - frr-pythontools
+
+# override defauts, use modern approach
+frr_apt_repository: "deb [signed-by=/etc/apt/keyrings/frrouting.gpg] https://deb.frrouting.org/frr {{ ansible_distribution_release }} {{ frr_apt_version }}"


### PR DESCRIPTION
Adds support for Debian 13/Trixie

## Description
This adds support for Debian 13/Trixie and a run for Molecule for Debian 13.

Apt handling for currently supported systems is not changed and needed some distribution checks on the tasks. For Debian 13 and future versions of Ubuntu (26.04) the apt repository configuration is changed a bit. It pins the signing gpg key to the repository.

## Related Issue
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.