### PR TITLE
Fix outdated GitHub Actions versions in CI workflow

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -16,11 +16,11 @@ jobs:
           - ubuntu2404
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - name: Set up Python 3
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip pip-tools


### PR DESCRIPTION
Fixes #145

## Summary
- `actions/checkout@v6` → `@v4`
- `actions/setup-python@v6` → `@v5`
- `python-version: "3.14"` → `"3.12"`

The v6 action versions do not exist and Python 3.14 is not a stable release, causing all CI runs to fail immediately.