### PR TITLE
Molecule add verify checks for Debian 11/12 and Ubuntu 22.04/24.04

### DIFF
--- a/molecule/debian11/verify.yml
+++ b/molecule/debian11/verify.yml
@@ -4,6 +4,42 @@
 - name: Verify
   hosts: all
   tasks:
-  - name: Example assertion
+  - name: Verify FRR package is installed
+    ansible.builtin.package_facts:
+      manager: apt
+
+  - name: Assert FRR is installed
     ansible.builtin.assert:
-      that: true
+      that: "'frr' in ansible_facts.packages"
+
+  - name: Find FRR key file in trusted.gpg.d
+    ansible.builtin.find:
+      paths: /etc/apt/trusted.gpg.d/
+      patterns: "*.gpg,*.asc"
+      excludes: "debian*"
+    register: _frr_verify_key_files
+
+  - name: Check legacy trusted.gpg
+    ansible.builtin.stat:
+      path: /etc/apt/trusted.gpg
+    register: _frr_verify_legacy_keyring
+
+  - name: Assert at least one key store is populated
+    ansible.builtin.assert:
+      that: >
+        _frr_verify_key_files.matched > 0 or
+        (_frr_verify_legacy_keyring.stat.exists and _frr_verify_legacy_keyring.stat.size > 0)
+  
+  - name: Get status of frr service
+    ansible.builtin.service:
+      name: frr
+    register: _frr_verify_service_status
+
+  - name: Assert frr service enabled and running
+    ansible.builtin.assert:
+      that:
+        - _frr_verify_service_status.status.ActiveState | default('n/a') == 'active'
+        - _frr_verify_service_status.status.LoadState | default('n/a') == 'loaded'
+        - _frr_verify_service_status.status.SubState | default('n/a') == 'running'
+        - _frr_verify_service_status.status.UnitFilePreset | default('n/a') == 'enabled'
+        - _frr_verify_service_status.status.UnitFileState | default('n/a') == 'enabled'

--- a/molecule/debian12/verify.yml
+++ b/molecule/debian12/verify.yml
@@ -4,6 +4,42 @@
 - name: Verify
   hosts: all
   tasks:
-  - name: Example assertion
+  - name: Verify FRR package is installed
+    ansible.builtin.package_facts:
+      manager: apt
+
+  - name: Assert FRR is installed
     ansible.builtin.assert:
-      that: true
+      that: "'frr' in ansible_facts.packages"
+
+  - name: Find FRR key file in trusted.gpg.d
+    ansible.builtin.find:
+      paths: /etc/apt/trusted.gpg.d/
+      patterns: "*.gpg,*.asc"
+      excludes: "debian*"
+    register: _frr_verify_key_files
+
+  - name: Check legacy trusted.gpg
+    ansible.builtin.stat:
+      path: /etc/apt/trusted.gpg
+    register: _frr_verify_legacy_keyring
+
+  - name: Assert at least one key store is populated
+    ansible.builtin.assert:
+      that: >
+        _frr_verify_key_files.matched > 0 or
+        (_frr_verify_legacy_keyring.stat.exists and _frr_verify_legacy_keyring.stat.size > 0)
+  
+  - name: Get status of frr service
+    ansible.builtin.service:
+      name: frr
+    register: _frr_verify_service_status
+
+  - name: Assert frr service enabled and running
+    ansible.builtin.assert:
+      that:
+        - _frr_verify_service_status.status.ActiveState | default('n/a') == 'active'
+        - _frr_verify_service_status.status.LoadState | default('n/a') == 'loaded'
+        - _frr_verify_service_status.status.SubState | default('n/a') == 'running'
+        - _frr_verify_service_status.status.UnitFilePreset | default('n/a') == 'enabled'
+        - _frr_verify_service_status.status.UnitFileState | default('n/a') == 'enabled'

--- a/molecule/ubuntu2204/verify.yml
+++ b/molecule/ubuntu2204/verify.yml
@@ -4,6 +4,42 @@
 - name: Verify
   hosts: all
   tasks:
-  - name: Example assertion
+  - name: Verify FRR package is installed
+    ansible.builtin.package_facts:
+      manager: apt
+
+  - name: Assert FRR is installed
     ansible.builtin.assert:
-      that: true
+      that: "'frr' in ansible_facts.packages"
+
+  - name: Find FRR key file in trusted.gpg.d
+    ansible.builtin.find:
+      paths: /etc/apt/trusted.gpg.d/
+      patterns: "*.gpg,*.asc"
+      excludes: "ubuntu*"
+    register: _frr_verify_key_files
+
+  - name: Check legacy trusted.gpg
+    ansible.builtin.stat:
+      path: /etc/apt/trusted.gpg
+    register: _frr_verify_legacy_keyring
+
+  - name: Assert at least one key store is populated
+    ansible.builtin.assert:
+      that: >
+        _frr_verify_key_files.matched > 0 or
+        (_frr_verify_legacy_keyring.stat.exists and _frr_verify_legacy_keyring.stat.size > 0)
+  
+  - name: Get status of frr service
+    ansible.builtin.service:
+      name: frr
+    register: _frr_verify_service_status
+
+  - name: Assert frr service enabled and running
+    ansible.builtin.assert:
+      that:
+        - _frr_verify_service_status.status.ActiveState | default('n/a') == 'active'
+        - _frr_verify_service_status.status.LoadState | default('n/a') == 'loaded'
+        - _frr_verify_service_status.status.SubState | default('n/a') == 'running'
+        - _frr_verify_service_status.status.UnitFilePreset | default('n/a') == 'enabled'
+        - _frr_verify_service_status.status.UnitFileState | default('n/a') == 'enabled'

--- a/molecule/ubuntu2404/verify.yml
+++ b/molecule/ubuntu2404/verify.yml
@@ -4,6 +4,42 @@
 - name: Verify
   hosts: all
   tasks:
-  - name: Example assertion
+  - name: Verify FRR package is installed
+    ansible.builtin.package_facts:
+      manager: apt
+
+  - name: Assert FRR is installed
     ansible.builtin.assert:
-      that: true
+      that: "'frr' in ansible_facts.packages"
+
+  - name: Find FRR key file in trusted.gpg.d
+    ansible.builtin.find:
+      paths: /etc/apt/trusted.gpg.d/
+      patterns: "*.gpg,*.asc"
+      excludes: "ubuntu*"
+    register: _frr_verify_key_files
+
+  - name: Check legacy trusted.gpg
+    ansible.builtin.stat:
+      path: /etc/apt/trusted.gpg
+    register: _frr_verify_legacy_keyring
+
+  - name: Assert at least one key store is populated
+    ansible.builtin.assert:
+      that: >
+        _frr_verify_key_files.matched > 0 or
+        (_frr_verify_legacy_keyring.stat.exists and _frr_verify_legacy_keyring.stat.size > 0)
+  
+  - name: Get status of frr service
+    ansible.builtin.service:
+      name: frr
+    register: _frr_verify_service_status
+
+  - name: Assert frr service enabled and running
+    ansible.builtin.assert:
+      that:
+        - _frr_verify_service_status.status.ActiveState | default('n/a') == 'active'
+        - _frr_verify_service_status.status.LoadState | default('n/a') == 'loaded'
+        - _frr_verify_service_status.status.SubState | default('n/a') == 'running'
+        - _frr_verify_service_status.status.UnitFilePreset | default('n/a') == 'enabled'
+        - _frr_verify_service_status.status.UnitFileState | default('n/a') == 'enabled'


### PR DESCRIPTION
## Description
Replaces the default Molecule verify checks of Debian 11/12 and Ubuntu 22.04/24.04 with actual checks.

## Related Issue
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
